### PR TITLE
Set CONTROL_REPO_DIR and dev mode.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,9 @@ content:
 mapping:
   image: quay.io/deconst/mapping-service
   environment:
-    CONTROL_REPO_URL: /var/control-repo
-    CONTROL_REPO_BRANCH:
+    CONTROL_REPO_DIR: /var/control-repo
     MAP_LOG_LEVEL: DEBUG
+    MAP_DEVELOPMENT_MODE: "true"
   ports:
   - "9001:8080"
   volumes:
@@ -29,9 +29,9 @@ mapping:
 layout:
   image: quay.io/deconst/layout-service
   environment:
-    CONTROL_REPO_URL: /var/control-repo
-    CONTROL_REPO_BRANCH:
+    CONTROL_REPO_DIR: /var/control-repo
     LAYOUT_LOG_LEVEL: DEBUG
+    LAYOUT_DEVELOPMENT_MODE: "true"
   ports:
   - "9002:8080"
   volumes:

--- a/env.example
+++ b/env.example
@@ -25,4 +25,3 @@ export PRESENTED_URL_DOMAIN=
 # Example: ${HOME}/writing/deconst-docs-control
 
 export CONTROL_REPO_PATH=
-export CONTROL_REPO_BRANCH=master


### PR DESCRIPTION
This makes the layout and mapping services use the live control repository in-place, without performing a `git clone` or deleting it.

It doesn't _quite_ get us 100% of the way there, unfortunately. When the layout service precompiles its layouts, it does so _in place_, which means that it would mess with your control repo and lose you work. When development mode is active, layout prerendering isn't being done properly, so you see the `[@ @]` and `[+ +]` prerendering directives left in the final page:

![screen shot 2015-06-12 at 7 36 20 am](https://cloud.githubusercontent.com/assets/17565/8129282/be0d141c-10d5-11e5-8f38-5cfa06522d13.png)

/cc @ktbartholomew 
