### PR TITLE
Update README, replacing boot2docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
  * Install a recent version of [Docker](https://docs.docker.com/installation/#installation) for your platform.
  * Install [docker-compose](https://docs.docker.com/compose/install/). In addition to the `curl` command they list, you can also install it from [homebrew](http://brew.sh/) or [pip](https://pypi.python.org/pypi/docker-compose/1.3.0rc1).
 
-If you're using `boot2docker` on a Mac or Windows, you'll need to make sure that it's running, first. Run `boot2docker init` on first run. 
+Make sure that docker-machine is running, first. Run `/usr/local/bin/docker-machine env default` to connect your Docker Client to the Docker Engine. 
 
-Run `boot2docker up` and then `$(boot2docker shellinit)` in each shell you'll use to interact with Docker.
+Run `eval $(/usr/local/bin/docker-machine env default)` in each shell you'll use to interact with Docker.
 
 ### Getting Started
 


### PR DESCRIPTION
Pretty Mac-specific, but it's what I did today to get Docker going with a fresh install.
