### PR TITLE
Update the preparer scripts to invoke the submitter.

### DIFF
--- a/script/add-jekyll
+++ b/script/add-jekyll
@@ -10,7 +10,7 @@ DECONST=$(docker-machine ip ${DOCKER_MACHINE_NAME})
 
 CONTENT_STORE_URL=http://${DECONST}:9000/
 
-if [ ${1:-} = "--stage" ] || [ ${1:-} = "-s" ]; then
+if [ "${1:-}" = "--stage" ] || [ "${1:-}" = "-s" ]; then
   CONTENT_STORE_URL=http://${DECONST}:9001/
   shift
 fi
@@ -29,20 +29,32 @@ fi
 # Acquire an API key.
 export CONTENT_STORE_APIKEY=$(curl -s \
   -X POST \
-  -H "Authorization: deconst apikey=\"${ADMIN_APIKEY}\"" \
+  -H "Authorization: deconst ${ADMIN_APIKEY}" \
   ${CONTENT_STORE_URL}keys?named=jekyll |
   python -c 'import sys, json; print json.load(sys.stdin)["apikey"]')
 
-# If a custom CONTENT_ID_BASE is set in the environment, use it.
-CONTENT_ID_ARG=
-[ -n "${CONTENT_ID_BASE:-}" ] && CONTENT_ID_ARG="-e CONTENT_ID_BASE=${CONTENT_ID_BASE}"
+# If a custom CONTENT_ID_BASE is set in the environment, use it. Otherwise, read it from your
+# _deconst.json file.
+if [ -z "${CONTENT_ID_BASE:-}" ]; then
+  CONTENT_ID_BASE=$(python -c "import json; print json.load(open('${1}/_deconst.json'))['contentIDBase']")
+fi
 
-# Run the Sphinx builder (from a Docker container) on the provided content repository.
-exec docker run \
+# Run the Jekyll builder (from a Docker container) on the provided content repository.
+docker run \
   --rm=true \
-  -e CONTENT_STORE_URL=${CONTENT_STORE_URL} \
-  -e CONTENT_STORE_APIKEY=${CONTENT_STORE_APIKEY} \
-  -e TRAVIS_PULL_REQUEST="false" \
-  ${CONTENT_ID_ARG} \
+  -e ENVELOPE_DIR=/usr/content-repo/_site/deconst-envelopes \
+  -e ASSET_DIR=/usr/content-repo/_site/deconst-assets \
+  -e CONTENT_ID_BASE=${CONTENT_ID_BASE} \
   -v ${1}:/usr/content-repo \
   quay.io/deconst/preparer-jekyll
+
+# Run the submitter on the generated output.
+docker run \
+  --rm=true \
+  -e ENVELOPE_DIR=/usr/content-repo/_site/deconst-envelopes \
+  -e ASSET_DIR=/usr/content-repo/_site/deconst-assets \
+  -e CONTENT_SERVICE_URL=${CONTENT_STORE_URL} \
+  -e CONTENT_SERVICE_APIKEY=${CONTENT_STORE_APIKEY} \
+  -e CONTENT_ID_BASE=${CONTENT_ID_BASE} \
+  -v ${1}:/usr/content-repo \
+  quay.io/deconst/submitter

--- a/script/add-jekyll
+++ b/script/add-jekyll
@@ -45,6 +45,7 @@ docker run \
   -e ENVELOPE_DIR=/usr/content-repo/_site/deconst-envelopes \
   -e ASSET_DIR=/usr/content-repo/_site/deconst-assets \
   -e CONTENT_ID_BASE=${CONTENT_ID_BASE} \
+  -e VERBOSE=${VERBOSE:-} \
   -v ${1}:/usr/content-repo \
   quay.io/deconst/preparer-jekyll
 
@@ -56,5 +57,6 @@ docker run \
   -e CONTENT_SERVICE_URL=${CONTENT_STORE_URL} \
   -e CONTENT_SERVICE_APIKEY=${CONTENT_STORE_APIKEY} \
   -e CONTENT_ID_BASE=${CONTENT_ID_BASE} \
+  -e VERBOSE=${VERBOSE:-} \
   -v ${1}:/usr/content-repo \
   quay.io/deconst/submitter

--- a/script/add-sphinx
+++ b/script/add-sphinx
@@ -45,6 +45,7 @@ docker run \
   -e ENVELOPE_DIR=/usr/content-repo/_build/deconst-envelopes \
   -e ASSET_DIR=/usr/content-repo/_build/deconst-assets \
   -e CONTENT_ID_BASE=${CONTENT_ID_BASE} \
+  -e VERBOSE=${VERBOSE:-} \
   -v ${1}:/usr/content-repo \
   quay.io/deconst/preparer-sphinx
 
@@ -56,5 +57,6 @@ docker run \
   -e CONTENT_SERVICE_URL=${CONTENT_STORE_URL} \
   -e CONTENT_SERVICE_APIKEY=${CONTENT_STORE_APIKEY} \
   -e CONTENT_ID_BASE=${CONTENT_ID_BASE} \
+  -e VERBOSE=${VERBOSE:-} \
   -v ${1}:/usr/content-repo \
   quay.io/deconst/submitter

--- a/script/add-sphinx
+++ b/script/add-sphinx
@@ -33,16 +33,18 @@ export CONTENT_STORE_APIKEY=$(curl -s \
   ${CONTENT_STORE_URL}keys?named=sphinx |
   python -c 'import sys, json; print json.load(sys.stdin)["apikey"]')
 
-# If a custom CONTENT_ID_BASE is set in the environment, use it.
-CONTENT_ID_ARG=
-[ -n "${CONTENT_ID_BASE:-}" ] && CONTENT_ID_ARG="-e CONTENT_ID_BASE=${CONTENT_ID_BASE}"
+# If a custom CONTENT_ID_BASE is set in the environment, use it. Otherwise, read it from your
+# _deconst.json file.
+if [ -z "${CONTENT_ID_BASE:-}" ]; then
+  CONTENT_ID_BASE=$(python -c "import json; print json.load(open('${1}/_deconst.json'))['contentIDBase']")
+fi
 
 # Run the Sphinx builder (from a Docker container) on the provided content repository.
 docker run \
   --rm=true \
   -e ENVELOPE_DIR=/usr/content-repo/_build/deconst-envelopes \
   -e ASSET_DIR=/usr/content-repo/_build/deconst-assets \
-  ${CONTENT_ID_ARG} \
+  -e CONTENT_ID_BASE=${CONTENT_ID_BASE} \
   -v ${1}:/usr/content-repo \
   quay.io/deconst/preparer-sphinx
 
@@ -53,6 +55,6 @@ docker run \
   -e ASSET_DIR=/usr/content-repo/_build/deconst-assets \
   -e CONTENT_SERVICE_URL=${CONTENT_STORE_URL} \
   -e CONTENT_SERVICE_APIKEY=${CONTENT_STORE_APIKEY} \
-  ${CONTENT_ID_ARG} \
+  -e CONTENT_ID_BASE=${CONTENT_ID_BASE} \
   -v ${1}:/usr/content-repo \
   quay.io/deconst/submitter

--- a/script/add-sphinx
+++ b/script/add-sphinx
@@ -29,7 +29,7 @@ fi
 # Acquire an API key.
 export CONTENT_STORE_APIKEY=$(curl -s \
   -X POST \
-  -H "Authorization: deconst apikey=\"${ADMIN_APIKEY}\"" \
+  -H "Authorization: deconst ${ADMIN_APIKEY}" \
   ${CONTENT_STORE_URL}keys?named=sphinx |
   python -c 'import sys, json; print json.load(sys.stdin)["apikey"]')
 

--- a/script/add-sphinx
+++ b/script/add-sphinx
@@ -10,7 +10,7 @@ DECONST=$(docker-machine ip ${DOCKER_MACHINE_NAME})
 
 CONTENT_STORE_URL=http://${DECONST}:9000/
 
-if [ ${1:-} = "--stage" ] || [ ${1:-} = "-s" ]; then
+if [ "${1:-}" = "--stage" ] || [ "${1:-}" = "-s" ]; then
   CONTENT_STORE_URL=http://${DECONST}:9001/
   shift
 fi

--- a/script/add-sphinx
+++ b/script/add-sphinx
@@ -38,11 +38,21 @@ CONTENT_ID_ARG=
 [ -n "${CONTENT_ID_BASE:-}" ] && CONTENT_ID_ARG="-e CONTENT_ID_BASE=${CONTENT_ID_BASE}"
 
 # Run the Sphinx builder (from a Docker container) on the provided content repository.
-exec docker run \
+docker run \
   --rm=true \
-  -e CONTENT_STORE_URL=${CONTENT_STORE_URL} \
-  -e CONTENT_STORE_APIKEY=${CONTENT_STORE_APIKEY} \
-  -e TRAVIS_PULL_REQUEST="false" \
+  -e ENVELOPE_DIR=/usr/content-repo/_build/deconst-envelopes \
+  -e ASSET_DIR=/usr/content-repo/_build/deconst-assets \
   ${CONTENT_ID_ARG} \
   -v ${1}:/usr/content-repo \
   quay.io/deconst/preparer-sphinx
+
+# Run the submitter on the generated output.
+docker run \
+  --rm=true \
+  -e ENVELOPE_DIR=/usr/content-repo/_build/deconst-envelopes \
+  -e ASSET_DIR=/usr/content-repo/_build/deconst-assets \
+  -e CONTENT_SERVICE_URL=${CONTENT_STORE_URL} \
+  -e CONTENT_SERVICE_APIKEY=${CONTENT_STORE_APIKEY} \
+  ${CONTENT_ID_ARG} \
+  -v ${1}:/usr/content-repo \
+  quay.io/deconst/submitter


### PR DESCRIPTION
It turns out that this is the easiest way to integration-test the submitter and the new preparer workflow.

Fixes #14.
