### PR TITLE
Allow the specification of an explicit CONTAINER_ROOT.

### DIFF
--- a/script/add-jekyll
+++ b/script/add-jekyll
@@ -39,24 +39,31 @@ if [ -z "${CONTENT_ID_BASE:-}" ]; then
   CONTENT_ID_BASE=$(python -c "import json; print json.load(open('${1}/_deconst.json'))['contentIDBase']")
 fi
 
+# Derive CONTAINER_ROOT.
+if [ -z "${CONTAINER_ROOT:-}" ]; then
+  CONTAINER_ROOT="$(cd ${1} && git rev-parse --show-toplevel)"
+fi
+
 # Run the Jekyll builder (from a Docker container) on the provided content repository.
 docker run \
   --rm=true \
-  -e ENVELOPE_DIR=/usr/content-repo/_site/deconst-envelopes \
-  -e ASSET_DIR=/usr/content-repo/_site/deconst-assets \
+  -e ENVELOPE_DIR=${CONTAINER_ROOT}/_site/deconst-envelopes \
+  -e ASSET_DIR=${CONTAINER_ROOT}/_site/deconst-assets \
   -e CONTENT_ID_BASE=${CONTENT_ID_BASE} \
   -e VERBOSE=${VERBOSE:-} \
-  -v ${1}:/usr/content-repo \
+  -e CONTENT_ROOT=${1} \
+  -v ${CONTAINER_ROOT}:${CONTAINER_ROOT} \
   quay.io/deconst/preparer-jekyll
 
 # Run the submitter on the generated output.
 docker run \
   --rm=true \
-  -e ENVELOPE_DIR=/usr/content-repo/_site/deconst-envelopes \
-  -e ASSET_DIR=/usr/content-repo/_site/deconst-assets \
+  -e ENVELOPE_DIR=${CONTAINER_ROOT}/_site/deconst-envelopes \
+  -e ASSET_DIR=${CONTAINER_ROOT}/_site/deconst-assets \
   -e CONTENT_SERVICE_URL=${CONTENT_STORE_URL} \
   -e CONTENT_SERVICE_APIKEY=${CONTENT_STORE_APIKEY} \
   -e CONTENT_ID_BASE=${CONTENT_ID_BASE} \
   -e VERBOSE=${VERBOSE:-} \
-  -v ${1}:/usr/content-repo \
+  -e CONTENT_ROOT=${1} \
+  -v ${CONTAINER_ROOT}:${CONTAINER_ROOT} \
   quay.io/deconst/submitter

--- a/script/add-sphinx
+++ b/script/add-sphinx
@@ -44,8 +44,6 @@ if [ -z "${CONTAINER_ROOT:-}" ]; then
   CONTAINER_ROOT="$(cd ${1} && git rev-parse --show-toplevel)"
 fi
 
-VOLUME_ARGS="-e CONTENT_ROOT=${1} -v ${CONTAINER_ROOT}:${CONTAINER_ROOT}"
-
 # Run the Sphinx builder (from a Docker container) on the provided content repository.
 docker run \
   --rm=true \

--- a/script/add-sphinx
+++ b/script/add-sphinx
@@ -39,14 +39,12 @@ if [ -z "${CONTENT_ID_BASE:-}" ]; then
   CONTENT_ID_BASE=$(python -c "import json; print json.load(open('${1}/_deconst.json'))['contentIDBase']")
 fi
 
-# If a container root has been specified explicitly, derive CONTENT_ROOT.
-if [ -n "${CONTAINER_ROOT:-}" ]; then
-  CONTAINER_PATH=${CONTAINER_ROOT#${1}}
-  VOLUME_ARGS="-e CONTENT_ROOT=${1} -v ${CONTAINER_ROOT}:${CONTAINER_ROOT}"
-else
-  CONTAINER_ROOT="/usr/content-repo"
-  VOLUME_ARGS="-v ${1}:${CONTAINER_ROOT}"
+# Derive CONTENT_ROOT.
+if [ -z "${CONTAINER_ROOT:-}" ]; then
+  CONTAINER_ROOT="$(cd ${1} && git rev-parse --show-toplevel)"
 fi
+
+VOLUME_ARGS="-e CONTENT_ROOT=${1} -v ${CONTAINER_ROOT}:${CONTAINER_ROOT}"
 
 # Run the Sphinx builder (from a Docker container) on the provided content repository.
 docker run \
@@ -55,7 +53,8 @@ docker run \
   -e ASSET_DIR=${CONTAINER_ROOT}/_build/deconst-assets \
   -e CONTENT_ID_BASE=${CONTENT_ID_BASE} \
   -e VERBOSE=${VERBOSE:-} \
-  ${VOLUME_ARGS} \
+  -e CONTENT_ROOT=${1} \
+  -v ${CONTAINER_ROOT}:${CONTAINER_ROOT} \
   quay.io/deconst/preparer-sphinx
 
 # Run the submitter on the generated output.
@@ -67,5 +66,6 @@ docker run \
   -e CONTENT_SERVICE_APIKEY=${CONTENT_STORE_APIKEY} \
   -e CONTENT_ID_BASE=${CONTENT_ID_BASE} \
   -e VERBOSE=${VERBOSE:-} \
-  ${VOLUME_ARGS} \
+  -e CONTENT_ROOT=${1} \
+  -v ${CONTAINER_ROOT}:${CONTAINER_ROOT} \
   quay.io/deconst/submitter

--- a/script/add-sphinx
+++ b/script/add-sphinx
@@ -39,7 +39,7 @@ if [ -z "${CONTENT_ID_BASE:-}" ]; then
   CONTENT_ID_BASE=$(python -c "import json; print json.load(open('${1}/_deconst.json'))['contentIDBase']")
 fi
 
-# Derive CONTENT_ROOT.
+# Derive CONTAINER_ROOT.
 if [ -z "${CONTAINER_ROOT:-}" ]; then
   CONTAINER_ROOT="$(cd ${1} && git rev-parse --show-toplevel)"
 fi

--- a/script/add-sphinx
+++ b/script/add-sphinx
@@ -39,24 +39,33 @@ if [ -z "${CONTENT_ID_BASE:-}" ]; then
   CONTENT_ID_BASE=$(python -c "import json; print json.load(open('${1}/_deconst.json'))['contentIDBase']")
 fi
 
+# If a container root has been specified explicitly, derive CONTENT_ROOT.
+if [ -n "${CONTAINER_ROOT:-}" ]; then
+  CONTAINER_PATH=${CONTAINER_ROOT#${1}}
+  VOLUME_ARGS="-e CONTENT_ROOT=${1} -v ${CONTAINER_ROOT}:${CONTAINER_ROOT}"
+else
+  CONTAINER_ROOT="/usr/content-repo"
+  VOLUME_ARGS="-v ${1}:${CONTAINER_ROOT}"
+fi
+
 # Run the Sphinx builder (from a Docker container) on the provided content repository.
 docker run \
   --rm=true \
-  -e ENVELOPE_DIR=/usr/content-repo/_build/deconst-envelopes \
-  -e ASSET_DIR=/usr/content-repo/_build/deconst-assets \
+  -e ENVELOPE_DIR=${CONTAINER_ROOT}/_build/deconst-envelopes \
+  -e ASSET_DIR=${CONTAINER_ROOT}/_build/deconst-assets \
   -e CONTENT_ID_BASE=${CONTENT_ID_BASE} \
   -e VERBOSE=${VERBOSE:-} \
-  -v ${1}:/usr/content-repo \
+  ${VOLUME_ARGS} \
   quay.io/deconst/preparer-sphinx
 
 # Run the submitter on the generated output.
 docker run \
   --rm=true \
-  -e ENVELOPE_DIR=/usr/content-repo/_build/deconst-envelopes \
-  -e ASSET_DIR=/usr/content-repo/_build/deconst-assets \
+  -e ENVELOPE_DIR=${CONTAINER_ROOT}/_build/deconst-envelopes \
+  -e ASSET_DIR=${CONTAINER_ROOT}/_build/deconst-assets \
   -e CONTENT_SERVICE_URL=${CONTENT_STORE_URL} \
   -e CONTENT_SERVICE_APIKEY=${CONTENT_STORE_APIKEY} \
   -e CONTENT_ID_BASE=${CONTENT_ID_BASE} \
   -e VERBOSE=${VERBOSE:-} \
-  -v ${1}:/usr/content-repo \
+  ${VOLUME_ARGS} \
   quay.io/deconst/submitter


### PR DESCRIPTION
Necessary to run against repositories that store assets outside of the Sphinx or Jekyll tree. Otherwise, the asset directories aren't mounted into the Docker containers.
