### PR TITLE
Support local control repositories more gracefully

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     ports:
     - "80:8080"
     environment:
-      CONTROL_REPO_PATH: /tmp/control-repo
+      CONTROL_REPO_PATH:
       CONTROL_REPO_URL:
       CONTROL_REPO_BRANCH:
       CONTENT_SERVICE_URL: http://content:8080/
@@ -38,6 +38,8 @@ services:
       PRESENTER_LIVERELOAD:
       PRESENTER_LOG_JSON: "false"
       PRESENTER_LOG_COLOR: "true"
+    volumes:
+    - "${CONTROL_REPO_HOST_PATH}:${CONTROL_REPO_PATH}"
   staging_content:
     image: quay.io/deconst/content-service
     ports:
@@ -62,7 +64,7 @@ services:
     ports:
     - "81:8080"
     environment:
-      CONTROL_REPO_PATH: /tmp/control-repo
+      CONTROL_REPO_PATH:
       CONTROL_REPO_URL:
       CONTROL_REPO_BRANCH:
       CONTENT_SERVICE_URL: http://staging_content:8080/
@@ -75,3 +77,5 @@ services:
       PRESENTER_LOG_JSON: "false"
       PRESENTER_LOG_COLOR: "true"
       STAGING_MODE: "true"
+    volumes:
+    - "${CONTROL_REPO_HOST_PATH}:${CONTROL_REPO_PATH}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       PRESENTER_LOG_JSON: "false"
       PRESENTER_LOG_COLOR: "true"
     volumes:
-    - "${CONTROL_REPO_HOST_PATH}:${CONTROL_REPO_PATH}"
+    - "${CONTROL_REPO_HOST_PATH}:${CONTROL_REPO_HOST_PATH}"
   staging_content:
     image: quay.io/deconst/content-service
     ports:
@@ -64,7 +64,7 @@ services:
     ports:
     - "81:8080"
     environment:
-      CONTROL_REPO_PATH:
+      CONTROL_REPO_PATH: /tmp/git-control-repo
       CONTROL_REPO_URL:
       CONTROL_REPO_BRANCH:
       CONTENT_SERVICE_URL: http://staging_content:8080/

--- a/env.example
+++ b/env.example
@@ -3,12 +3,46 @@
 # cp env.example env
 # ${EDITOR} env
 
-# Determine the storage backend
+# Universal settings ###############################################################################
+# You'll need to set these whatever you're doing.
+
+# The content service's administrative API Key. Used for write actions.
+# Set this to something arbitrary and "random". While you're running locally it doesn't need to
+# be anything particularly difficult.
+export ADMIN_APIKEY=
+
+# Set this to the domain name of the site you're interested in.
+export PRESENTED_URL_DOMAIN=deconst.horse
+
+# Determine the storage backend.
 # Use "memory" for in memory storage or "remote" for Cloud Files storage
-export STORAGE=remote
+export STORAGE=memory
+
+# Control repository settings ######################################################################
+# Customize the control repository used by your local Deconst instance.
+
+# To preview local changes to a control repository:
+
+# Set this to a path to a control repository on your local machine to preview local changes to a
+# control repository.
+
+export CONTROL_REPO_HOST_PATH=
+
+# To use a control repository from a remote git repository:
+
+# Set these to a valid git URL and branch.
+export CONTROL_REPO_URL=https://github.com/deconst/deconst-docs-control.git
+export CONTENT_REPO_BRANCH=master
+
+# A task to be run in the control repo's directory to build/upload assets
+export CONTROL_REPO_ASSETS_TASK="grunt build"
+
+# Storage settings #################################################################################
+# Control where Deconst stores assets.
+# These only need to be set if you've changed STORAGE to "remote" in the Universal settings.
 
 # Rackspace credentials.
-# These are only used for Cloud Files.
+# These are only used for Cloud Files and are only necessary if STORAGE is set to "remote".
 
 export RACKSPACE_USERNAME=
 export RACKSPACE_APIKEY=
@@ -21,24 +55,26 @@ export CONTAINER_NAME=integrated
 export CONTENT_CONTAINER=deconst-${CONTAINER_NAME}-content
 export ASSET_CONTAINER=deconst-${CONTAINER_NAME}-asset
 
-# The content service's API Key. Used for write actions.
-export ADMIN_APIKEY=
+# Template settings ################################################################################
+# These settings only do anything if the templates in the control repository you're using read them.
 
-# Set this to the domain name of the final site.
-export PRESENTED_URL_DOMAIN=deconst.horse
-
-# "true" or "false", whether the presenter should load assets directly from the
-# control repo, or via the assets container
+# "true" or "false", whether the presenter should load assets directly from the control repo, or
+# via the assets container
 export PRESENTER_DEVMODE=
 
 # "true" or "false", whether the presenter should inject a Livereload script in
 # the body. Doesn't do anything unless your templates watch this variable.
 export PRESENTER_LIVERELOAD=
 
-# Control repository settings.
-# Set these to a git URL and branch to read the control repository from a git repository.
-export CONTROL_REPO_URL=https://github.com/deconst/deconst-docs-control.git
-export CONTENT_REPO_BRANCH=master
+# Internal stuff ###################################################################################
+# Bash munging to simplify some of the settings above and derive related variables. You shouldn't
+# need to edit anything here unless you're debugging this repo.
 
-# A task to be run in the control repo's directory to build/upload assets
-export CONTROL_REPO_ASSETS_TASK="grunt build"
+# Derive the container-internal CONTROL_REPO_PATH from the other CONTROL_REPO_* variables.
+
+if [ -n "${CONTROL_REPO_HOST_PATH}" ]; then
+  export CONTROL_REPO_PATH="${CONTROL_REPO_HOST_PATH}"
+else
+  CONTROL_REPO_HOST_PATH=$(pwd)
+  export CONTROL_REPO_PATH=/tmp/control-repo
+fi

--- a/env.example
+++ b/env.example
@@ -76,9 +76,9 @@ export PRESENTER_LIVERELOAD=
 
 if [ -n "${CONTROL_REPO_HOST_PATH}" ]; then
   if [ -n "${CONTROL_REPO_URL}" ]; then
-    echo "Please ensure that CONTROL_REPO_URL is unset when CONTROL_REPO_HOST_PATH is set." >&2
-    echo "Otherwise, the presenter will blow away all of your changes!"
-    return 1
+    unset CONTROL_REPO_URL
+    unset CONTROL_REPO_BRANCH
+    echo "Ignoring CONTROL_REPO_URL in favor of CONTROL_REPO_HOST_PATH." >&2
   fi
 
   export CONTROL_REPO_PATH="${CONTROL_REPO_HOST_PATH}"

--- a/env.example
+++ b/env.example
@@ -75,6 +75,12 @@ export PRESENTER_LIVERELOAD=
 # Derive the container-internal CONTROL_REPO_PATH from the other CONTROL_REPO_* variables.
 
 if [ -n "${CONTROL_REPO_HOST_PATH}" ]; then
+  if [ -n "${CONTROL_REPO_URL}" ]; then
+    echo "Please ensure that CONTROL_REPO_URL is unset." >&2
+    echo "Otherwise, the presenter will blow away all of your changes!"
+    exit 1
+  fi
+
   export CONTROL_REPO_PATH="${CONTROL_REPO_HOST_PATH}"
 else
   CONTROL_REPO_HOST_PATH=$(pwd)

--- a/env.example
+++ b/env.example
@@ -24,15 +24,17 @@ export STORAGE=memory
 # To preview local changes to a control repository:
 
 # Set this to a path to a control repository on your local machine to preview local changes to a
-# control repository.
+# control repository. Be sure to leave CONTROL_REPO_URL unset.
 
 export CONTROL_REPO_HOST_PATH=
 
 # To use a control repository from a remote git repository:
 
 # Set these to a valid git URL and branch.
-export CONTROL_REPO_URL=https://github.com/deconst/deconst-docs-control.git
-export CONTENT_REPO_BRANCH=master
+# export CONTROL_REPO_URL=https://github.com/deconst/deconst-docs-control.git
+# export CONTENT_REPO_BRANCH=master
+export CONTROL_REPO_URL=
+export CONTENT_REPO_BRANCH=
 
 # A task to be run in the control repo's directory to build/upload assets
 export CONTROL_REPO_ASSETS_TASK="grunt build"

--- a/env.example
+++ b/env.example
@@ -76,9 +76,9 @@ export PRESENTER_LIVERELOAD=
 
 if [ -n "${CONTROL_REPO_HOST_PATH}" ]; then
   if [ -n "${CONTROL_REPO_URL}" ]; then
-    echo "Please ensure that CONTROL_REPO_URL is unset." >&2
+    echo "Please ensure that CONTROL_REPO_URL is unset when CONTROL_REPO_HOST_PATH is set." >&2
     echo "Otherwise, the presenter will blow away all of your changes!"
-    exit 1
+    return 1
   fi
 
   export CONTROL_REPO_PATH="${CONTROL_REPO_HOST_PATH}"


### PR DESCRIPTION
Provide a mechanism to mount a local control repository into the presenter containers as a volume to more gracefully support control repository development.

If this works you'll be able to change:

``` bash
export CONTROL_REPO_HOST_PATH=
```

... to a path on your host and iterate on control repository changes there.

I think you'll still need to restart the presenters to pick up new changes, though.

/cc @bighappyface @ktbartholomew 
