### PR TITLE
Use correct asset URLs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       ADMIN_APIKEY:
       CONTENT_CONTAINER:
       ASSET_CONTAINER:
+      MEMORY_ASSET_PREFIX:
       MONGODB_URL: mongodb://mongo:27017/content
       ELASTICSEARCH_HOST: http://elasticsearch:9200/
       CONTENT_LOG_LEVEL: debug
@@ -53,6 +54,7 @@ services:
       ADMIN_APIKEY:
       CONTENT_CONTAINER: "staging-${CONTENT_CONTAINER}"
       ASSET_CONTAINER: "staging-${ASSET_CONTAINER}"
+      MEMORY_ASSET_PREFIX: "${STAGING_MEMORY_ASSET_PREFIX}"
       MONGODB_URL: mongodb://mongo:27017/content
       MONGODB_PREFIX: staging_
       CONTENT_LOG_LEVEL: debug

--- a/env.example
+++ b/env.example
@@ -91,7 +91,7 @@ fi
 # Set MEMORY_ASSET_PREFIX appropriately depending on whether you're using docker-machine or the
 # Docker for (Mac|Windows) betas.
 
-if [ -z "${DOCKER_HOST}" ]; then
+if [ -z "${DOCKER_HOST:-}" ]; then
   # Defaulting to the local Docker socket.
   # Use localhost.
   export DECONST_PUBLIC=localhost

--- a/env.example
+++ b/env.example
@@ -87,3 +87,20 @@ else
   export CONTROL_REPO_HOST_PATH=$(pwd)
   export CONTROL_REPO_PATH=/tmp/control-repo
 fi
+
+# Set MEMORY_ASSET_PREFIX appropriately depending on whether you're using docker-machine or the
+# Docker for (Mac|Windows) betas.
+
+if [ -z "${DOCKER_HOST}" ]; then
+  # Defaulting to the local Docker socket.
+  # Use localhost.
+  export DECONST_PUBLIC=localhost
+else
+  # Yank it from DOCKER_HOST.
+  # This should work from docker-machine and Carina.
+  export DECONST_PUBLIC=${DOCKER_HOST#tcp://}
+  DECONST_PUBLIC=${DECONST_PUBLIC%:[0-9]*}
+fi
+
+export MEMORY_ASSET_PREFIX=http://${DECONST_PUBLIC}:9000/assets/
+export STAGING_MEMORY_ASSET_PREFIX=http://${DECONST_PUBLIC}:9001/assets/


### PR DESCRIPTION
Once deconst/content-service#112 is in, I'll be able to point assets directly to the content service's `/assets/:filename` endpoint.
