### PR TITLE
Update elasticsearch image to 6.2.1 version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   mongo:
     image: mongo:2.6
   elasticsearch:
-    image: elasticsearch:1.7
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.2.1
   content:
     image: quay.io/deconst/content-service
     ports:


### PR DESCRIPTION
Updated the docker-compose.yml elasticsearch version to 6.2.1. This needs to be used in conjunction with the updated content-service image.

fixed #23 